### PR TITLE
Add a Pipfile for easier pipenv support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+wikidataintegrator = "==0.0.498"
+pywikibot = "*"
+pandas = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"


### PR DESCRIPTION
Because pipenv is the bomb! Also because we need a specific version of
WikidataIntegrator, before they changed the wdi_property_store structure.

Signed-off-by: Dan Scott <dscott@laurentian.ca>